### PR TITLE
Updating Link Status - Read or Unread

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,0 +1,3 @@
+.read {
+  text-decoration: line-through;
+}

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -21,6 +21,16 @@ class LinksController < ApplicationController
     end
   end
 
+  def update
+    link = Link.find(params[:id])
+    if params[:clicked]
+      read_property = !link.read
+      link.update_attributes(read: read_property)
+      flash[:success] = "Link marked as read!"
+    end
+    redirect_to links_path
+  end
+
   private
     def link_params
       params.require(:link).permit(:url, :title)

--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -12,5 +12,10 @@
   <% @links.each do |link| %>
     <h4><%= link.title %></h4>
     <h4><%= link.url %></h4>
+    <% if !link.read %>
+      <%= button_to "Mark as Read", link_path(link), params: { clicked: true }, :method => :put %>
+    <% else %>
+      <%= button_to "Mark as Unread", link_path(link), params: { clicked: true }, :method => :put %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -10,8 +10,8 @@
 <% end %>
 <% if @links %>
   <% @links.each do |link| %>
-    <h4><%= link.title %></h4>
-    <h4><%= link.url %></h4>
+    <h4 class="<%= link.read ? 'read' : 'unread' %>"><%= link.title %></h4>
+    <h4 class="<%= link.read ? 'read' : 'unread' %>"><%= link.url %></h4>
     <% if !link.read %>
       <%= button_to "Mark as Read", link_path(link), params: { clicked: true }, :method => :put %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete "logout", to: "sessions#destroy"
 
   resources :users, only: [:new, :create]
-  resources :links, only: [:index, :create]
+  resources :links, only: [:index, :create, :update]
 end

--- a/spec/features/user_marks_link_as_read_spec.rb
+++ b/spec/features/user_marks_link_as_read_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.feature "User marks link as read" do
+  scenario "the link is then marked as read" do
+    user = User.create(email: "email@example.com", password: "password")
+    link = user.links.create(url: "http://www.google.com", title: "google")
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    expect(link.read).to eq(false)
+
+    visit links_path
+
+    click_on "Mark as Read"
+
+    expect(current_path).to eq(links_path)
+
+    expect(page).to have_button("Mark as Unread")
+    expect(page).to_not have_button("Mark as Read")
+  end
+end

--- a/spec/features/user_marks_link_as_unread_spec.rb
+++ b/spec/features/user_marks_link_as_unread_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.feature "User marks link as read" do
+  scenario "the link is then marked as read" do
+    user = User.create(email: "email@example.com", password: "password")
+    link = user.links.create(url: "http://www.google.com", title: "google")
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    link.update_attributes(read: true)
+    expect(link.read).to eq(true)
+
+    visit links_path
+
+    click_on "Mark as Unread"
+
+    expect(current_path).to eq(links_path)
+
+    expect(page).to have_button("Mark as Read")
+    expect(page).to_not have_button("Mark as Unread")
+  end
+end


### PR DESCRIPTION
User can now mark his/her links as read or unread through button presses. Links default to unread. When read/unread buttons are pressed, the attribute for that link is updated, and the link's class is changed accordingly.

-Added update action in link controller (and route)
-Added buttons to Mark as Read and Mark as Unread (based on link's attribute)
-Added dynamic classes using ternary to style Links based on read or unread (strike-through read links)
