### PR TITLE
Editing Thoughts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'bcrypt', '~> 3.1.7'
 gem 'figaro'
 gem 'pg'
+gem 'responders'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     rake (11.1.2)
     rdoc (4.2.2)
       json (~> 1.4)
+    responders (2.2.0)
+      railties (>= 4.2.0, < 5.1)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -201,6 +203,7 @@ DEPENDENCIES
   pg
   quiet_assets
   rails (= 4.2.5.1)
+  responders
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/assets/javascripts/editThought.js
+++ b/app/assets/javascripts/editThought.js
@@ -1,0 +1,5 @@
+// "use strict";
+//
+// module.exports = function(idea) {
+//
+// }

--- a/app/assets/javascripts/thoughts.js
+++ b/app/assets/javascripts/thoughts.js
@@ -8,7 +8,7 @@ $('document').ready(function() {
 
 function editThought(){
   let thought_id = $(this).parent().data("thought-id");
-  let thought = $("div[data-thought-id*="+ thought_id + "]")
+  let thought = $("div[data-thought-id*="+ thought_id + "]");
   let thoughtParams = {
     thought: {
       url : $(thought).children('.url').text(),
@@ -20,6 +20,14 @@ function editThought(){
     url: "/api/v1/links/" + thought_id,
     method: "PUT",
     dataType: "json",
-    data: thoughtParams
+    data: thoughtParams,
+    success: function() {
+      alert("Thought updated!")
+      location.reload();
+    },
+    error: function() {
+      alert("URL needs to be in a proper format.");
+      location.reload();
+    }
   })
 }

--- a/app/assets/javascripts/thoughts.js
+++ b/app/assets/javascripts/thoughts.js
@@ -3,11 +3,11 @@
 // let editThought = require('editThought');
 
 $('document').ready(function() {
-  $('body').on("blur", ".thought", editThought);
+  $('body').on("click", ".edit", editThought);
 })
 
 function editThought(){
-  let thought_id = $(this).data("thought-id");
+  let thought_id = $(this).parent().data("thought-id");
   let thought = $("div[data-thought-id*="+ thought_id + "]")
   let thoughtParams = {
     thought: {

--- a/app/assets/javascripts/thoughts.js
+++ b/app/assets/javascripts/thoughts.js
@@ -1,0 +1,25 @@
+"use strict";
+
+// let editThought = require('editThought');
+
+$('document').ready(function() {
+  $('body').on("blur", ".thought", editThought);
+})
+
+function editThought(){
+  let thought_id = $(this).data("thought-id");
+  let thought = $("div[data-thought-id*="+ thought_id + "]")
+  let thoughtParams = {
+    thought: {
+      url : $(thought).children('.url').text(),
+      title : $(thought).children('.title').text()
+    }
+  };
+
+  $.ajax({
+    url: "/api/v1/links/" + thought_id,
+    method: "PUT",
+    dataType: "json",
+    data: thoughtParams
+  })
+}

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,0 +1,3 @@
+class Api::ApiController < ApplicationController
+  protect_from_forgery with: :null_session
+end

--- a/app/controllers/api/v1/links_controller.rb
+++ b/app/controllers/api/v1/links_controller.rb
@@ -3,7 +3,6 @@ class Api::V1::LinksController < Api::ApiController
 
   def update
     link = Link.find(params[:id])
-    # byebug
     if link.update(link_params)
       respond_with link, location: nil
     end

--- a/app/controllers/api/v1/links_controller.rb
+++ b/app/controllers/api/v1/links_controller.rb
@@ -2,8 +2,8 @@ class Api::V1::LinksController < Api::ApiController
   respond_to :json
 
   def update
-    # byebug
     link = Link.find(params[:id])
+    # byebug
     if link.update(link_params)
       respond_with link, location: nil
     end
@@ -11,6 +11,6 @@ class Api::V1::LinksController < Api::ApiController
 
   private
     def link_params
-      params.require(:link).permit(:url, :title)
+      params.require(:thought).permit(:url, :title)
     end
 end

--- a/app/controllers/api/v1/links_controller.rb
+++ b/app/controllers/api/v1/links_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::LinksController < Api::ApiController
+  respond_to :json
+
+  def update
+    # byebug
+    link = Link.find(params[:id])
+    if link.update(link_params)
+      respond_with link, location: nil
+    end
+  end
+
+  private
+    def link_params
+      params.require(:link).permit(:url, :title)
+    end
+end

--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -18,6 +18,7 @@
       <% else %>
         <%= button_to "Mark as Unread", link_path(link), params: { clicked: true }, :method => :put %>
       <% end %>
+      <button class="edit">Edit</button>
     </div>
   <% end %>
 <% end %>

--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -10,12 +10,14 @@
 <% end %>
 <% if @links %>
   <% @links.each do |link| %>
-    <h4 class="<%= link.read ? 'read' : 'unread' %>"><%= link.title %></h4>
-    <h4 class="<%= link.read ? 'read' : 'unread' %>"><%= link.url %></h4>
-    <% if !link.read %>
-      <%= button_to "Mark as Read", link_path(link), params: { clicked: true }, :method => :put %>
-    <% else %>
-      <%= button_to "Mark as Unread", link_path(link), params: { clicked: true }, :method => :put %>
-    <% end %>
+    <div class="thought" data-thought-id="<%= link.id %>">
+      <h4 class="<%= link.read ? 'read' : 'unread' %> title" contenteditable="true"><%= link.title %></h4>
+      <p class="<%= link.read ? 'read' : 'unread' %> url" contenteditable="true"><%= link.url %></p>
+      <% if !link.read %>
+        <%= button_to "Mark as Read", link_path(link), params: { clicked: true }, :method => :put %>
+      <% else %>
+        <%= button_to "Mark as Unread", link_path(link), params: { clicked: true }, :method => :put %>
+      <% end %>
+    </div>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,10 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create]
   resources :links, only: [:index, :create, :update]
+
+  namespace :api do
+    namespace :v1 do
+      resources :links, only: [:update], defaults: { format: :json }
+    end
+  end
 end

--- a/spec/features/user_edits_link_spec.rb
+++ b/spec/features/user_edits_link_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.feature "User edits link" do
+  scenario "they see the new link info" do
+    user = User.create(email: "email@example.com", password: "password")
+    link = user.links.create(url: "http://www.google.com", title: "google")
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit links_path
+
+    url = find(:xpath,"//*[normalize-space()='http://www.google.com']", match: :first)
+    url.click
+    # title.sendKeys("Updated-Title")
+    title = find(:xpath,"//*[normalize-space()='google']", match: :first)
+    title.click
+  end
+end


### PR DESCRIPTION
User can edit thought URL's and Titles. 

-Fields have content editable attributes.
-Event listener for clicking on edit button; once pressed, will send thought params to api update action.
-Based on success or failure (a bad url, for example), the user gets an alert about the success or failure and the page reloads.
